### PR TITLE
Update invisibles to match vscode

### DIFF
--- a/Dracula.novaextension/Themes/Dracula.css
+++ b/Dracula.novaextension/Themes/Dracula.css
@@ -71,7 +71,7 @@ meta.text {
   color: #f8f8f2;
 }
 meta.text.invisible {
-  color: #6272a4;
+  color: hsla(0, 0%, 100%, 0.15);
 }
 meta.text.selected {
   background-color: #44475a;


### PR DESCRIPTION
I had to see the invisibles in a file recently and the characters are a lot harsher than the ones in vscode. This PR updates the `meta.text.invisible` style to more closely match that in vscode. I used the `hsla` format as Nova didn't seem to support the 8-letter hex codes that the vscode definition uses. If there is a specification for the exact colour it should be, I'll happily set it to that.

**vscode**

<img width="583" alt="vscode" src="https://user-images.githubusercontent.com/1526174/144049794-969f0977-27e2-4dc6-bc85-f4882eacd35a.png">

**nova before**

<img width="541" alt="nova-before" src="https://user-images.githubusercontent.com/1526174/144049812-1ebd6eda-6d77-4dcc-a3f0-93bde2fe9a33.png">

**nova after**

<img width="553" alt="nova-after" src="https://user-images.githubusercontent.com/1526174/144049829-7d7698ae-0381-4d27-8bf0-56eb8a88bb24.png">

> The difference doesn't seem as noticeable in the small screenshots, but when it is a whole file and it is full screen, it makes a big difference!